### PR TITLE
Removed unnecessary dependencies ( SnapKit )

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,6 @@ target 'YARCH' do
   use_frameworks!
 
   # Pods for YARCH
-  pod 'SnapKit'
   pod 'SwiftLint'
 
   target 'YARCHTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,21 +1,18 @@
 PODS:
   - Nimble (7.0.2)
   - Quick (1.2.0)
-  - SnapKit (4.0.0)
   - SwiftLint (0.24.0)
 
 DEPENDENCIES:
   - Nimble
   - Quick
-  - SnapKit
   - SwiftLint
 
 SPEC CHECKSUMS:
   Nimble: bfe1f814edabba69ff145cb1283e04ed636a67f2
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
-  SnapKit: a42d492c16e80209130a3379f73596c3454b7694
   SwiftLint: a014c92b4664e8b13f380f8640a51bb1733778ba
 
-PODFILE CHECKSUM: 285a0c389b267bb2c6ec256ae4c04e7f9ae59c28
+PODFILE CHECKSUM: e089d9c77240b72aa67e2da2393cb703e131b424
 
 COCOAPODS: 1.3.1

--- a/YARCH/Sources/LoadingTableView/LoadingSectionHeaderView.swift
+++ b/YARCH/Sources/LoadingTableView/LoadingSectionHeaderView.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SnapKit
 
 /// Представление заголовка секции для состояния загрузки таблицы
 extension LoadingSectionHeaderView {
@@ -33,11 +32,13 @@ class LoadingSectionHeaderView: UITableViewHeaderFooterView {
     }
 
     func makeConstraints() {
-        grayView.snp.makeConstraints { make in
-            make.width.greaterThanOrEqualTo(appearance.grayViewMinimumSize.width)
-            make.top.left.equalToSuperview().inset(appearance.grayViewInsets)
-            make.right.lessThanOrEqualToSuperview().offset(-appearance.grayViewInsets.right).priority(appearance.rightEdgeConstraintPriority)
-            make.bottom.equalToSuperview().offset(-appearance.grayViewInsets.bottom)
-        }
+        grayView.translatesAutoresizingMaskIntoConstraints = false
+        grayView.widthAnchor.constraint(greaterThanOrEqualToConstant: appearance.grayViewMinimumSize.width).isActive = true
+        grayView.topAnchor.constraint(equalTo: topAnchor, constant: appearance.grayViewInsets.top).isActive = true
+        grayView.leftAnchor.constraint(equalTo: leftAnchor, constant: appearance.grayViewInsets.left).isActive = true
+        let right = grayView.rightAnchor.constraint(lessThanOrEqualTo: rightAnchor, constant: -appearance.grayViewInsets.right)
+        right.priority = .init(rawValue: Float(appearance.rightEdgeConstraintPriority))
+        right.isActive = true
+        grayView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -appearance.grayViewInsets.bottom).isActive = true
     }
 }

--- a/YARCH/Sources/LoadingTableView/LoadingTableViewCell.swift
+++ b/YARCH/Sources/LoadingTableView/LoadingTableViewCell.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SnapKit
 
 ///  Ячейка таблицы в состоянии загрузки
 extension LoadingTableViewCell {
@@ -44,6 +43,7 @@ class LoadingTableViewCell: UITableViewCell {
     func configureView(radius: CGFloat) -> UIView {
         let view = UIView()
         view.backgroundColor = self.appearance.backgroundColor
+        view.translatesAutoresizingMaskIntoConstraints = false
         view.setRadius(radius: radius)
         return view
     }
@@ -60,32 +60,32 @@ class LoadingTableViewCell: UITableViewCell {
     }
 
     func makeConstraints() {
-        circle.snp.makeConstraints { make in
-            make.width.equalTo(circle.snp.height)
-            make.top.left.bottom.equalToSuperview().inset(appearance.circleInsets)
-        }
+        circle.widthAnchor.constraint(equalTo: circle.heightAnchor).isActive = true
+        circle.topAnchor.constraint(equalTo: contentView.topAnchor, constant: appearance.circleInsets.top).isActive = true
+        circle.leftAnchor.constraint(equalTo: contentView.leftAnchor, constant: appearance.circleInsets.left).isActive = true
+        circle.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -appearance.circleInsets.bottom).isActive = true
 
-        topView.snp.makeConstraints { make in
-            make.size.greaterThanOrEqualTo(appearance.topLineSize)
-            make.top.equalToSuperview().offset(appearance.topInsets.top)
-            make.left.equalTo(circle.snp.right).offset(appearance.topInsets.left)
-            make.right.lessThanOrEqualTo(rightView.snp.left).offset(-appearance.topInsets.right).priority(appearance.rightEdgeConstraintPriority)
-            make.bottom.equalTo(bottomView.snp.top).offset(-appearance.topInsets.bottom)
-        }
+        topView.widthAnchor.constraint(greaterThanOrEqualToConstant: appearance.topLineSize.width).isActive = true
+        topView.heightAnchor.constraint(greaterThanOrEqualToConstant: appearance.topLineSize.height).isActive = true
+        topView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: appearance.topInsets.top).isActive = true
+        topView.leftAnchor.constraint(equalTo: circle.rightAnchor, constant: appearance.topInsets.left).isActive = true
+        let topViewRight = topView.rightAnchor.constraint(lessThanOrEqualTo: rightView.leftAnchor, constant: -appearance.topInsets.right)
+        topViewRight.priority = .init(rawValue: Float(appearance.rightEdgeConstraintPriority))
+        topViewRight.isActive = true
+        topView.bottomAnchor.constraint(equalTo: bottomView.topAnchor, constant: -appearance.topInsets.bottom).isActive = true
 
-        bottomView.snp.makeConstraints { make in
-            make.size.greaterThanOrEqualTo(appearance.bottomLineSize)
-            make.top.equalTo(topView.snp.bottom).offset(appearance.bottomInsets.top)
-            make.left.equalTo(circle.snp.right).offset(appearance.bottomInsets.left)
-            make.right.lessThanOrEqualToSuperview().offset(-appearance.bottomInsets.right).priority(appearance.rightEdgeConstraintPriority)
-            make.bottom.equalToSuperview().offset(-appearance.bottomInsets.bottom)
-        }
+        bottomView.widthAnchor.constraint(greaterThanOrEqualToConstant: appearance.bottomLineSize.width).isActive = true
+        bottomView.heightAnchor.constraint(greaterThanOrEqualToConstant: appearance.bottomLineSize.height).isActive = true
+        bottomView.topAnchor.constraint(equalTo: topView.bottomAnchor, constant: appearance.bottomInsets.top).isActive = true
+        bottomView.leftAnchor.constraint(equalTo: circle.rightAnchor, constant: appearance.bottomInsets.left).isActive = true
+        let bottomViewRight = bottomView.rightAnchor.constraint(lessThanOrEqualTo: contentView.rightAnchor, constant: -appearance.bottomInsets.right)
+        bottomViewRight.priority = .init(rawValue: Float(appearance.rightEdgeConstraintPriority))
+        bottomViewRight.isActive = true
+        bottomView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -appearance.bottomInsets.bottom).isActive = true
 
-        rightView.snp.makeConstraints { make in
-            make.width.equalTo(appearance.rightLineSize.width)
-            make.top.right.equalToSuperview().inset(appearance.rightInsets)
-            make.bottom.equalTo(bottomView.snp.top).offset(-appearance.rightInsets.bottom)
-        }
-
+        rightView.widthAnchor.constraint(equalToConstant: appearance.rightLineSize.width).isActive = true
+        rightView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: appearance.rightInsets.top).isActive = true
+        rightView.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -appearance.rightInsets.right).isActive = true
+        rightView.bottomAnchor.constraint(equalTo: bottomView.topAnchor, constant: -appearance.rightInsets.bottom).isActive = true
     }
 }

--- a/YARCH/Sources/LoadingTableView/LoadingTableViewDelegate.swift
+++ b/YARCH/Sources/LoadingTableView/LoadingTableViewDelegate.swift
@@ -15,7 +15,7 @@ class LoadingTableViewDelegate: NSObject, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-       return tableView.dequeueReusableHeaderFooterWithRegistration(type: LoadingSectionHeaderView.self)
+        return tableView.dequeueReusableHeaderFooterWithRegistration(type: LoadingSectionHeaderView.self)
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/YARCH/Sources/Modules/Catalog/View/CatalogCell.swift
+++ b/YARCH/Sources/Modules/Catalog/View/CatalogCell.swift
@@ -1,6 +1,5 @@
 import Foundation
 import UIKit
-import SnapKit
 
 class CatalogCell: UITableViewCell {
 
@@ -12,10 +11,10 @@ class CatalogCell: UITableViewCell {
     }
 
     lazy var title: UILabel = {
-        let typeLabel = UILabel()
-        typeLabel.textColor = self.appearance.titleColor
-        typeLabel.numberOfLines = 2
-        return typeLabel
+        let label = UILabel()
+        label.textColor = self.appearance.titleColor
+        label.numberOfLines = 2
+        return label
     }()
 
     lazy var separator: UIView = {
@@ -46,14 +45,16 @@ class CatalogCell: UITableViewCell {
     }
 
     func setupConstraints() {
-        title.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(appearance.labelOffset)
-        }
+        title.translatesAutoresizingMaskIntoConstraints = false
+        title.topAnchor.constraint(equalTo: contentView.topAnchor, constant: appearance.labelOffset).isActive = true
+        title.leftAnchor.constraint(equalTo: contentView.leftAnchor, constant: appearance.labelOffset).isActive = true
+        title.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -appearance.labelOffset).isActive = true
+        title.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -appearance.labelOffset).isActive = true
 
-        separator.snp.makeConstraints { make in
-            make.right.bottom.equalToSuperview()
-            make.height.equalTo(appearance.separatorHeight)
-            make.left.equalToSuperview().offset(appearance.labelOffset)
-        }
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        separator.rightAnchor.constraint(equalTo: contentView.rightAnchor).isActive = true
+        separator.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+        separator.heightAnchor.constraint(equalToConstant: appearance.separatorHeight).isActive = true
+        separator.leftAnchor.constraint(equalTo: contentView.leftAnchor, constant: appearance.labelOffset).isActive = true
     }
 }

--- a/YARCH/Sources/Modules/Catalog/View/CatalogEmptyView.swift
+++ b/YARCH/Sources/Modules/Catalog/View/CatalogEmptyView.swift
@@ -1,5 +1,4 @@
 import UIKit
-import SnapKit
 
 class CatalogEmptyView: UIView {
     class Appearance {
@@ -60,18 +59,20 @@ class CatalogEmptyView: UIView {
     }
 
     func makeConstraints() {
-        view.snp.makeConstraints { make in
-            make.left.right.centerY.equalToSuperview()
-        }
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
+        view.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
+        view.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
 
-        title.snp.makeConstraints { make in
-            make.top.equalToSuperview()
-            make.left.right.equalToSuperview().inset(appearance.titleInsets)
-        }
+        title.translatesAutoresizingMaskIntoConstraints = false
+        title.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        title.leftAnchor.constraint(equalTo: leftAnchor, constant: appearance.titleInsets.left).isActive = true
+        title.rightAnchor.constraint(equalTo: rightAnchor, constant: -appearance.titleInsets.right).isActive = true
 
-        subtitle.snp.makeConstraints { make in
-            make.top.equalTo(title.snp.bottom).offset(appearance.subtitleInsets.top)
-            make.left.right.bottom.equalToSuperview().inset(appearance.subtitleInsets)
-        }
+        subtitle.translatesAutoresizingMaskIntoConstraints = false
+        subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: appearance.subtitleInsets.top).isActive = true
+        subtitle.leftAnchor.constraint(equalTo: leftAnchor, constant: appearance.subtitleInsets.left).isActive = true
+        subtitle.rightAnchor.constraint(equalTo: rightAnchor, constant: -appearance.subtitleInsets.right).isActive = true
+        subtitle.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -appearance.subtitleInsets.bottom).isActive = true
     }
 }

--- a/YARCH/Sources/Modules/Catalog/View/CatalogErrorView.swift
+++ b/YARCH/Sources/Modules/Catalog/View/CatalogErrorView.swift
@@ -61,16 +61,14 @@ class CatalogErrorView: UIView {
     }
 
     func makeConstraints() {
-        title.snp.makeConstraints { make in
-            make.centerY.equalToSuperview()
-            make.left.equalToSuperview().offset(appearance.titleInsets.left)
-            make.right.equalToSuperview().offset(-appearance.titleInsets.right)
-        }
+        title.translatesAutoresizingMaskIntoConstraints = false
+        title.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+        title.leftAnchor.constraint(equalTo: leftAnchor, constant: appearance.titleInsets.left).isActive = true
+        title.rightAnchor.constraint(equalTo: rightAnchor, constant: -appearance.titleInsets.right).isActive = true
 
-        refreshButton.snp.makeConstraints { make in
-            make.centerX.equalTo(title.snp.centerX)
-            make.top.equalTo(title.snp.bottom).offset(appearance.refreshButtonInsets.top)
-        }
+        refreshButton.translatesAutoresizingMaskIntoConstraints = false
+        refreshButton.centerXAnchor.constraint(equalTo: title.centerXAnchor).isActive = true
+        refreshButton.topAnchor.constraint(equalTo: title.bottomAnchor, constant: appearance.refreshButtonInsets.top).isActive = true
     }
 
     @objc

--- a/YARCH/Sources/Modules/Catalog/View/CatalogView.swift
+++ b/YARCH/Sources/Modules/Catalog/View/CatalogView.swift
@@ -46,17 +46,23 @@ class CatalogView: UIView {
     }
 
     func makeConstraints() {
-        tableView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        tableView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        tableView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
+        tableView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
 
-        emptyView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
+        emptyView.translatesAutoresizingMaskIntoConstraints = false
+        emptyView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        emptyView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        emptyView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
+        emptyView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
 
-        errorView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
-        }
+        errorView.translatesAutoresizingMaskIntoConstraints = false
+        errorView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        errorView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        errorView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
+        errorView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
     }
 
     func showEmptyView(title: String, subtitle: String) {


### PR DESCRIPTION
**Proposal:**
The best way for project example: 
1) The user download a ZIP
2) The user does not need to install 'cocoapods'
3) The user run .xcodeproj file without ‘pod install'
3.1) or run .xcworkspace file with ‘Development Pods’ in project.
4) ???????
5) PROFIT

**Changes:**
Removed unnecessary dependencies ( SnapKit ) for reduce entry in an architecture.
The SnapKit was replaced by a layout anchors.